### PR TITLE
German (de_DE) translation

### DIFF
--- a/po/CREDITS.json
+++ b/po/CREDITS.json
@@ -10,5 +10,8 @@
     ],
     "Swedish": [
         "Åke Engelbrektson <eson@svenskasprakfiler.se>"
+    ],
+    "German": [
+        "Luke Röper <contact@roeper-luke.de>"
     ]
 }

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,2 +1,2 @@
 # Space separated list
-fr it ru sv
+de fr it ru sv

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,135 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Luke Röper <contact@roeper-luke.de>, 2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: timeswitch\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-11-03 23:22+0300\n"
+"PO-Revision-Date: 2022-11-08 23:11+0100\n"
+"Last-Translator: Luke Röper <contact@roeper-luke.de>\n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Gtranslator 40.0\n"
+
+#: data/io.github.fsobolev.TimeSwitch.desktop.in:3
+#: data/io.github.fsobolev.TimeSwitch.appdata.xml.in:6
+msgid "Time Switch"
+msgstr "Time Switch"
+
+#: data/io.github.fsobolev.TimeSwitch.desktop.in:6
+#: data/io.github.fsobolev.TimeSwitch.appdata.xml.in:7
+msgid "Power off, reboot, suspend or send a notification on timer."
+msgstr ""
+"Herunterfahren, Neustarten, in Ruhemodus versetzen oder eine "
+"Benachrichtigung nach dem Ablauf der Zeit versenden."
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: data/io.github.fsobolev.TimeSwitch.desktop.in:10
+msgid "timer;shutdown;poweroff;reboot;suspend;notification;"
+msgstr ""
+"stoppuhr;zeit;ablauf;herunterfahren;ausschalten;ruhemodus;standby;"
+"benachrichtigung;"
+
+#: data/io.github.fsobolev.TimeSwitch.appdata.xml.in:9
+msgid ""
+"Time Switch is a simple program that allows you to power off, reboot or "
+"suspend your system, or send a notification (optionally with a sound signal) "
+"on timer."
+msgstr ""
+"Time Switch ist ein simples Programm, dass es dir erlaubt, beim Ablauf der "
+"Zeit das Gerät herunterzufahren, neuzustarten, in Bereitschaft zu versetzen "
+"oder eine Benachrichtigung (optional mit Ton) zu versenden."
+
+#: data/io.github.fsobolev.TimeSwitch.appdata.xml.in:10
+msgid ""
+"The app is built for GNOME and uses LibAdwaita, but it works in any desktop "
+"environment."
+msgstr ""
+"Die App ist für GNOME gebaut und nutzt LibAdwaita, funktioniert jedoch in "
+"jeder Desktop-Umgebung."
+
+#: data/io.github.fsobolev.TimeSwitch.appdata.xml.in:15
+msgid "Fyodor Sobolev"
+msgstr "Fyodor Sobolev"
+
+#: src/actions.py:83
+msgid "Timer has finished!"
+msgstr "Die Zeit ist abgelaufen!"
+
+#: src/timer.py:42
+msgid "Your device will be powered off in"
+msgstr "Das Gerät wird heruntergefahren in"
+
+#: src/timer.py:44
+msgid "Your device will be rebooted in"
+msgstr "Das Gerät wird neugestartet in"
+
+#: src/timer.py:46
+msgid "Your device will be suspended in"
+msgstr "Das Gerät geht in Bereitschaft in"
+
+#: src/timer.py:48
+msgid "You will receive a notification in"
+msgstr "Du wirst eine Benachrichtigung erhalten in"
+
+#. Translators: Short fot "minutes"
+#: src/window.py:124
+msgid "min"
+msgstr "min"
+
+#. Translators: Short for "seconds"
+#: src/window.py:124
+msgid "sec"
+msgstr "sek"
+
+#: src/window.py:140
+msgid "Reset"
+msgstr "Zurücksetzen"
+
+#: src/window.py:148
+msgid "Action"
+msgstr "Aktion"
+
+#: src/window.py:153
+msgid "Power Off"
+msgstr "Herunterfahren"
+
+#: src/window.py:162
+msgid "Reboot"
+msgstr "Neustarten"
+
+#: src/window.py:171
+msgid "Suspend"
+msgstr "Bereitschaft"
+
+#: src/window.py:180
+msgid "Notification"
+msgstr "Benachrichtigung"
+
+#: src/window.py:203
+msgid "Notification text"
+msgstr "Benachrichtigungstext"
+
+#: src/window.py:207
+msgid "Play sound"
+msgstr "Ton abspielen"
+
+#: src/window.py:224
+msgid "Start"
+msgstr "Start"
+
+#: src/window.py:265
+msgid "Stop"
+msgstr "Stop"
+
+#: src/window.py:278
+msgid "You can close the window, the timer will work in the background."
+msgstr "Du kannst das Fenster schließen, die Zeit läuft im Hintergrund weiter."


### PR DESCRIPTION
Translated to German (de_DE)

I used the term "Bereitschaft" for "Suspend" as this is what Gnome also calls it.
![grafik](https://user-images.githubusercontent.com/29387023/200688356-8a34789e-35c6-4883-be90-182c7fd7a855.png)
In German (at least in Germany / de_DE ), this however is normally called "Ruhemodus". I have never heard or seen the term "Bereitschaft" anywhere else.

Also, the term "Timer"  also exists in the spoken German Language, but we tend to use "Zeit" ( = "Time" ) like in "Die Zeit ist abgelaufen" ( = "The Time is up / has run out") instead. Using "Der Timer ist abgelaufen" would be possible, but more unusual.